### PR TITLE
Fixes toggling bug

### DIFF
--- a/battleships-game/app.js
+++ b/battleships-game/app.js
@@ -131,14 +131,16 @@ document.addEventListener("DOMContentLoaded", () => {
             battleship.classList.toggle('battleship-container-vertical');
             carrier.classList.toggle('carrier-container-vertical'); 
             isHorizontal = false;
+            return
         }
         if (!isHorizontal) {
-            destroyer.classList.toggle('destroyer-container');
-            submarine.classList.toggle('submarine-container');
-            cruiser.classList.toggle('cruiser-container');
-            battleship.classList.toggle('battleship-container');
-            carrier.classList.toggle('carrier-container'); 
+            destroyer.classList.toggle('destroyer-container-vertical');
+            submarine.classList.toggle('submarine-container-vertical');
+            cruiser.classList.toggle('cruiser-container-vertical');
+            battleship.classList.toggle('battleship-container-vertical');
+            carrier.classList.toggle('carrier-container-vertical'); 
             isHorizontal = true;
+            return
         }
     }
     // attaches the 👆 rotate function to the rotate button 👇


### PR DESCRIPTION
I was conceptualizing the .toggle method incorrectly. The '-vertical' was absent from the end of the class name. I added it, and a return from the function that was also missing.